### PR TITLE
Switch case fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ script:
   - export GO111MODULE="on"
   - go install -v ./...
   - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+  - find ./ -name "gop_autogen.go"|grep "testdata" |xargs -n 1 go build
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -144,6 +144,7 @@ func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 	out := ctx.out
 	done := ctx.NewLabel("")
 	hasTag := v.Tag != nil
+	hasCaseClause := false
 	if hasTag {
 		if len(v.Body.List) == 0 {
 			return
@@ -159,6 +160,7 @@ func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 				defaultBody = c.Body
 				continue
 			}
+			hasCaseClause = true
 			for _, caseExp := range c.List {
 				compileExpr(ctxSw, caseExp)()
 				checkCaseCompare(tag, ctx.infer.Pop(), out)
@@ -180,6 +182,7 @@ func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 				defaultBody = c.Body
 				continue
 			}
+			hasCaseClause = true
 			next := ctx.NewLabel("")
 			last := len(c.List) - 1
 			if last == 0 {
@@ -206,7 +209,9 @@ func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 	if defaultBody != nil {
 		compileBodyWith(ctxSw, defaultBody)
 	}
-	out.Label(done)
+	if hasCaseClause {
+		out.Label(done)
+	}
 }
 
 func compileIfStmt(ctx *blockCtx, v *ast.IfStmt) {

--- a/cl/stmt_test.go
+++ b/cl/stmt_test.go
@@ -229,10 +229,6 @@ var fsTestSw3 = asttest.NewSingleFileFS("/foo", "bar.gop", `
 	switch t {
 	default:
 		x = 7
-	case "world", "hi":
-		x = 5
-	case "xsw":
-		x = 3
 	}
 	x
 `)

--- a/exec/golang/testdata/12.flow/flow.gop
+++ b/exec/golang/testdata/12.flow/flow.gop
@@ -38,3 +38,15 @@ default:
     x = 11
 }
 println("x:", x)
+
+switch{}
+
+switch v {
+default:
+    println(v)
+}
+
+switch y:=v; y {
+default:
+    println(y)
+}


### PR DESCRIPTION
make qgo support empty-switch and only-default-branch switch
```go
switch{}

switch v {
default:
    println(v)
}

switch y:=v; y {
default:
    println(y)
}
```
