### PR TITLE
Enrich pre-commit hooks and call them from Travis CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
-- repo: git://github.com/dnephin/pre-commit-golang
-  rev: master
-  hooks:
-    - id: go-fmt
+repos:
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: master
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+      - id: go-cyclo
+        args: [-over=100]
+      - id: no-go-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: go
 go:
   - "1.14"
+install:
+  - go get golang.org/x/tools/cmd/goimports
+  - go get github.com/fzipp/gocyclo/cmd/gocyclo
 script:
   - export GO111MODULE="on"
   - go install -v ./...
   - go test -race -coverprofile=coverage.txt -covermode=atomic ./...
   - find ./ -name "gop_autogen.go"|grep "testdata" |xargs -n 1 go build
+  - pre-commit run --all
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 install:
   - go get golang.org/x/tools/cmd/goimports
   - go get github.com/golangci/gocyclo/cmd/gocyclo
-  - pip install -y pre-commit
+  - pip install pre-commit
 script:
   - export GO111MODULE="on"
   - go install -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
   - "1.14"
 install:
   - go get golang.org/x/tools/cmd/goimports
-  - go get github.com/fzipp/gocyclo/cmd/gocyclo
+  - go get github.com/golangci/gocyclo/cmd/gocyclo
 script:
   - export GO111MODULE="on"
   - go install -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 install:
   - go get golang.org/x/tools/cmd/goimports
   - go get github.com/golangci/gocyclo/cmd/gocyclo
-  - sudo pip install pre-commit
+  - sudo pip --quiet install pre-commit
 script:
   - export GO111MODULE="on"
   - go install -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 install:
   - go get golang.org/x/tools/cmd/goimports
   - go get github.com/golangci/gocyclo/cmd/gocyclo
+  - pip install -y pre-commit
 script:
   - export GO111MODULE="on"
   - go install -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 install:
   - go get golang.org/x/tools/cmd/goimports
   - go get github.com/golangci/gocyclo/cmd/gocyclo
-  - pip install pre-commit
+  - sudo pip install pre-commit
 script:
   - export GO111MODULE="on"
   - go install -v ./...


### PR DESCRIPTION
- go-imports prints no errors.
- no-go-testing prints no errors.
- go-cyclo shows a lot of errors until I set `-over` up to 100. **In future PRs, we should edit code to reduce the parameter down to about 20**.