### PR TITLE
Slight simplify source code of pakcage token

### DIFF
--- a/token/position.go
+++ b/token/position.go
@@ -20,110 +20,6 @@ import (
 	"go/token"
 )
 
-// -----------------------------------------------------------------------------
-/*
-// Token is the set of lexical tokens of Go+.
-type Token = token.Token
-
-// The list of tokens.
-const (
-	IDENT  = token.IDENT  // main
-	INT    = token.INT    // 12345
-	FLOAT  = token.FLOAT  // 123.45
-	IMAG   = token.IMAG   // 123.45i
-	CHAR   = token.CHAR   // 'a'
-	STRING = token.STRING // "abc"
-
-	ADD = token.ADD // +
-	SUB = token.SUB // -
-	MUL = token.MUL // *
-	QUO = token.QUO // /
-	REM = token.REM // %
-
-	AND     = token.AND     // &
-	OR      = token.OR      // |
-	XOR     = token.XOR     // ^
-	SHL     = token.SHL     // <<
-	SHR     = token.SHR     // >>
-	AND_NOT = token.AND_NOT // &^
-
-	ADD_ASSIGN = token.ADD_ASSIGN // +=
-	SUB_ASSIGN = token.SUB_ASSIGN // -=
-	MUL_ASSIGN = token.MUL_ASSIGN // *=
-	QUO_ASSIGN = token.QUO_ASSIGN // /=
-	REM_ASSIGN = token.REM_ASSIGN // %=
-
-	AND_ASSIGN     = token.AND_ASSIGN     // &=
-	OR_ASSIGN      = token.OR_ASSIGN      // |=
-	XOR_ASSIGN     = token.XOR_ASSIGN     // ^=
-	SHL_ASSIGN     = token.SHL_ASSIGN     // <<=
-	SHR_ASSIGN     = token.SHR_ASSIGN     // >>=
-	AND_NOT_ASSIGN = token.AND_NOT_ASSIGN // &^=
-
-	LAND  = token.LAND  // &&
-	LOR   = token.LOR   // ||
-	ARROW = token.ARROW // <-
-	INC   = token.INC   // ++
-	DEC   = token.DEC   // --
-
-	EQL    = token.EQL    // ==
-	LSS    = token.LSS    // <
-	GTR    = token.GTR    // >
-	ASSIGN = token.ASSIGN // =
-	NOT    = token.NOT    // !
-
-	NEQ      = token.NEQ      // !=
-	LEQ      = token.LEQ      // <=
-	GEQ      = token.GEQ      // >=
-	DEFINE   = token.DEFINE   // :=
-	ELLIPSIS = token.ELLIPSIS // ...
-
-	LPAREN = token.LPAREN // (
-	LBRACK = token.LBRACK // [
-	LBRACE = token.LBRACE // {
-	COMMA  = token.COMMA  // ,
-	PERIOD = token.PERIOD // .
-
-	RPAREN    = token.RPAREN    // )
-	RBRACK    = token.RBRACK    // ]
-	RBRACE    = token.RBRACE    // }
-	SEMICOLON = token.SEMICOLON // ;
-	COLON     = token.COLON     // :
-
-	// Keywords
-	BREAK    = token.BREAK
-	CASE     = token.CASE
-	CHAN     = token.CHAN
-	CONST    = token.CONST
-	CONTINUE = token.CONTINUE
-
-	DEFAULT     = token.DEFAULT
-	DEFER       = token.DEFER
-	ELSE        = token.ELSE
-	FALLTHROUGH = token.FALLTHROUGH
-	FOR         = token.FOR
-
-	FUNC   = token.FUNC
-	GO     = token.GO
-	GOTO   = token.GOTO
-	IF     = token.IF
-	IMPORT = token.IMPORT
-
-	INTERFACE = token.INTERFACE
-	MAP       = token.MAP
-	PACKAGE   = token.PACKAGE
-	RANGE     = token.RANGE
-	RETURN    = token.RETURN
-
-	SELECT = token.SELECT
-	STRUCT = token.STRUCT
-	SWITCH = token.SWITCH
-	TYPE   = token.TYPE
-	VAR    = token.VAR
-)
-*/
-// -----------------------------------------------------------------------------
-
 // Pos is a compact encoding of a source position within a file set.
 // It can be converted into a Position for a more convenient, but much
 // larger, representation.
@@ -147,10 +43,10 @@ const (
 type Pos = token.Pos
 
 const (
-	// NoPos - The zero value for Pos is NoPos; there is no file and line information
-	// associated with it, and NoPos.IsValid() is false. NoPos is always smaller
-	// than any other Pos value. The corresponding Position value for NoPos is
-	// the zero value for Position.
+	// NoPos - The zero value for Pos is NoPos; there is no file and line
+	// information associated with it, and NoPos.IsValid() is false. NoPos
+	// is always smaller than any other Pos value. The corresponding
+	// Position value for NoPos is the zero value for Position.
 	NoPos = token.NoPos
 )
 
@@ -163,13 +59,11 @@ type Position = token.Position
 // A File has a name, size, and line offset table.
 type File = token.File
 
-// A FileSet represents a set of source files. Methods of file sets are synchronized;
-// multiple goroutines may invoke them concurrently.
+// A FileSet represents a set of source files. Methods of file sets are
+// synchronized; multiple goroutines may invoke them concurrently.
 type FileSet = token.FileSet
 
 // NewFileSet creates a new file set.
 func NewFileSet() *FileSet {
 	return token.NewFileSet()
 }
-
-// -----------------------------------------------------------------------------

--- a/token/token.go
+++ b/token/token.go
@@ -8,9 +8,8 @@
 package token
 
 import (
+	"go/token"
 	"strconv"
-	"unicode"
-	"unicode/utf8"
 )
 
 // Token is the set of lexical tokens of the Go programming language.
@@ -318,16 +317,13 @@ func (tok Token) IsKeyword() bool { return keyword_beg < tok && tok < keyword_en
 // IsExported reports whether name starts with an upper-case letter.
 //
 func IsExported(name string) bool {
-	ch, _ := utf8.DecodeRuneInString(name)
-	return unicode.IsUpper(ch)
+	return token.IsExported(name)
 }
 
 // IsKeyword reports whether name is a Go keyword, such as "func" or "return".
 //
 func IsKeyword(name string) bool {
-	// TODO: opt: use a perfect hash function instead of a global map.
-	_, ok := keywords[name]
-	return ok
+	return token.IsKeyword(name)
 }
 
 // IsIdentifier reports whether name is a Go identifier, that is, a non-empty
@@ -335,10 +331,5 @@ func IsKeyword(name string) bool {
 // is not a digit. Keywords are not identifiers.
 //
 func IsIdentifier(name string) bool {
-	for i, c := range name {
-		if !unicode.IsLetter(c) && c != '_' && (i == 0 || !unicode.IsDigit(c)) {
-			return false
-		}
-	}
-	return name != "" && !IsKeyword(name)
+	return token.IsIdentifier(name)
 }


### PR DESCRIPTION
- Remove the comment of the source code block.
- Remove source code redundant with https://golang.org/src/go/token/token.go?s=5620:5653#L316 