### PR TITLE
cmd/qexp: add -outdir flag, format export pkg code.

### DIFF
--- a/cmd/qexp/gopkg/exporter_test.go
+++ b/cmd/qexp/gopkg/exporter_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"go/importer"
 	"go/types"
-	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -100,50 +99,36 @@ func TestFixPkgString(t *testing.T) {
 
 // -----------------------------------------------------------------------------
 
-type nopCloser struct {
-	io.Writer
-}
-
-func (nopCloser) Close() error { return nil }
-
-func nilExportFile(pkgDir string) (f io.WriteCloser, err error) {
-	return &nopCloser{ioutil.Discard}, nil
-}
-
-func stdoutExportFile(pkgDir string) (f io.WriteCloser, err error) {
-	return &nopCloser{os.Stdout}, nil
-}
-
 func TestExportStrings(t *testing.T) {
-	err := Export("strings", nilExportFile)
+	err := Export("strings", ioutil.Discard)
 	if err != nil {
 		t.Fatal("TestExport failed:", err)
 	}
 }
 
 func TestExportStrconv(t *testing.T) {
-	err := Export("strconv", nilExportFile)
+	err := Export("strconv", ioutil.Discard)
 	if err != nil {
 		t.Fatal("TestExport failed:", err)
 	}
 }
 
 func TestExportReflect(t *testing.T) {
-	err := Export("reflect", nilExportFile)
+	err := Export("reflect", ioutil.Discard)
 	if err != nil {
 		t.Fatal("TestExport failed:", err)
 	}
 }
 
 func TestExportIo(t *testing.T) {
-	err := Export("io", stdoutExportFile)
+	err := Export("io", os.Stdout)
 	if err != nil {
 		t.Fatal("TestExport failed:", err)
 	}
 }
 
 func TestExportGoTypes(t *testing.T) {
-	err := Export("go/types", nilExportFile)
+	err := Export("go/types", ioutil.Discard)
 	if err != nil {
 		t.Fatal("TestExport failed:", err)
 	}

--- a/cmd/qexp/gopkg/exporter_test.go
+++ b/cmd/qexp/gopkg/exporter_test.go
@@ -134,4 +134,15 @@ func TestExportGoTypes(t *testing.T) {
 	}
 }
 
+func TestPackage(t *testing.T) {
+	pkg, err := Import("go/build")
+	if err != nil {
+		t.Fatal("TestPackage Import failed:", err)
+	}
+	err = ExportPackage(pkg, ioutil.Discard)
+	if err != nil {
+		t.Fatal("TestPackage ExportPackage failed:", err)
+	}
+}
+
 // -----------------------------------------------------------------------------

--- a/cmd/qexp/qexport.go
+++ b/cmd/qexp/qexport.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -75,9 +76,13 @@ func exportPkg(pkgPath string, libDir string) error {
 	if err != nil {
 		return err
 	}
+	data, err := format.Source(buf.Bytes())
+	if err != nil {
+		return err
+	}
 	dir := filepath.Join(libDir, pkg.Path())
 	os.MkdirAll(dir, 0777)
-	err = ioutil.WriteFile(filepath.Join(dir, "gomod_export.go"), buf.Bytes(), 0666)
+	err = ioutil.WriteFile(filepath.Join(dir, "gomod_export.go"), data, 0666)
 	return err
 }
 

--- a/cmd/qexp/qexport.go
+++ b/cmd/qexp/qexport.go
@@ -17,22 +17,23 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"flag"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/qiniu/goplus/cmd/qexp/gopkg"
 )
 
 var (
-	exportFile string
+	flagExportDir string
 )
 
-func createExportFile(pkgDir string) (f io.WriteCloser, err error) {
-	os.MkdirAll(pkgDir, 0777)
-	exportFile = pkgDir + "/gomod_export.go"
-	return os.Create(exportFile)
+func init() {
+	flag.StringVar(&flagExportDir, "outdir", "", "optional set export lib path, default goplus/lib path")
 }
 
 func main() {
@@ -42,18 +43,77 @@ func main() {
 		flag.PrintDefaults()
 		return
 	}
-	pkgPath := flag.Arg(0)
-	defer func() {
-		if exportFile != "" {
-			os.Remove(exportFile)
+	var libDir string
+	if flagExportDir != "" {
+		libDir = flagExportDir
+	} else {
+		root, err := goplusRoot()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "find goplus root failed:", err)
+			os.Exit(-1)
 		}
-	}()
-	err := gopkg.Export(pkgPath, createExportFile)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "export failed:", err)
-		os.Exit(1)
+		libDir = filepath.Join(root, "lib")
 	}
-	exportFile = "" // don't remove file if success
+
+	for _, pkgPath := range flag.Args() {
+		err := exportPkg(pkgPath, libDir)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "export pkg failed:", err)
+		} else {
+			fmt.Fprintln(os.Stdout, "export pkg success:", pkgPath)
+		}
+	}
+}
+
+func exportPkg(pkgPath string, libDir string) error {
+	pkg, err := gopkg.Import(pkgPath)
+	if err != nil {
+		return err
+	}
+	var buf bytes.Buffer
+	err = gopkg.ExportPackage(pkg, &buf)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(libDir, pkg.Path())
+	os.MkdirAll(dir, 0777)
+	err = ioutil.WriteFile(filepath.Join(dir, "gomod_export.go"), buf.Bytes(), 0666)
+	return err
+}
+
+func goplusRoot() (root string, err error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for {
+		modfile := filepath.Join(dir, "go.mod")
+		if hasFile(modfile) {
+			if isGoplus(modfile) {
+				return dir, nil
+			}
+			return "", errors.New("current directory is not under goplus root")
+		}
+		next := filepath.Dir(dir)
+		if dir == next {
+			return "", errors.New("go.mod not found, please run under goplus root")
+		}
+		dir = next
+	}
+}
+
+func isGoplus(modfile string) bool {
+	b, err := ioutil.ReadFile(modfile)
+	return err == nil && bytes.HasPrefix(b, goplusPrefix)
+}
+
+var (
+	goplusPrefix = []byte("module github.com/qiniu/goplus")
+)
+
+func hasFile(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular()
 }
 
 // -----------------------------------------------------------------------------

--- a/cmd/qexp/qexport.go
+++ b/cmd/qexp/qexport.go
@@ -40,7 +40,7 @@ func init() {
 func main() {
 	flag.Parse()
 	if flag.NArg() < 1 {
-		fmt.Fprintf(os.Stderr, "Usage: qexp <goPkgPath>\n")
+		fmt.Fprintf(os.Stderr, "Usage: qexp [packages]\n")
 		flag.PrintDefaults()
 		return
 	}


### PR DESCRIPTION
 move goplusRoot from cmd/qexp/gopkg to cmd/qexp,
add -outdir flag for customes set export lib path, default goplus/lib.
support multiple packages exported.
