### PR TITLE
qexp: add export const and vars

### DIFF
--- a/cmd/qexp/gopkg/export.go
+++ b/cmd/qexp/gopkg/export.go
@@ -44,7 +44,8 @@ func exportTypeName(e *Exporter, o *types.TypeName) (err error) {
 	return nil
 }
 
-func exportVar(o *types.Var) (err error) {
+func exportVar(e *Exporter, o *types.Var) (err error) {
+	e.ExportVar(o)
 	return nil
 }
 
@@ -72,7 +73,7 @@ func ExportPackage(pkg *types.Package, w io.Writer) (err error) {
 		}
 		switch o := obj.(type) {
 		case *types.Var:
-			err = exportVar(o)
+			err = exportVar(e, o)
 		case *types.Const:
 			err = exportConst(e, o)
 		case *types.TypeName:

--- a/cmd/qexp/gopkg/export.go
+++ b/cmd/qexp/gopkg/export.go
@@ -48,7 +48,8 @@ func exportVar(o *types.Var) (err error) {
 	return nil
 }
 
-func exportConst(o *types.Const) (err error) {
+func exportConst(e *Exporter, o *types.Const) (err error) {
+	e.ExportConst(o)
 	return nil
 }
 
@@ -74,7 +75,7 @@ func ExportPackage(pkg *types.Package, w io.Writer) (err error) {
 		case *types.Var:
 			err = exportVar(o)
 		case *types.Const:
-			err = exportConst(o)
+			err = exportConst(e, o)
 		case *types.TypeName:
 			err = exportTypeName(e, o)
 		case *types.Func:

--- a/cmd/qexp/gopkg/export.go
+++ b/cmd/qexp/gopkg/export.go
@@ -49,8 +49,7 @@ func exportVar(o *types.Var) (err error) {
 }
 
 func exportConst(e *Exporter, o *types.Const) (err error) {
-	e.ExportConst(o)
-	return nil
+	return e.ExportConst(o)
 }
 
 func Import(pkgPath string) (*types.Package, error) {

--- a/cmd/qexp/gopkg/exporter.go
+++ b/cmd/qexp/gopkg/exporter.go
@@ -351,10 +351,10 @@ func (p *Exporter) ExportConst(typ *types.Const) error {
 		_, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
 			if value[0] == '-' {
-				c.kind = specName + "." + ".Int64"
+				c.kind = specName + ".Int64"
 				c.val = "int64(" + fullName + ")"
 			} else {
-				c.kind = specName + "." + "Uint64"
+				c.kind = specName + ".Uint64"
 				c.val = "uint64(" + fullName + ")"
 			}
 		}

--- a/cmd/qexp/gopkg/exporter.go
+++ b/cmd/qexp/gopkg/exporter.go
@@ -325,13 +325,9 @@ $argInit	$retAssign$fn($args)
 	return nil
 }
 
-const (
-	specName = "spec"
-)
-
 // ExportConst exports a go consts.
 func (p *Exporter) ExportConst(typ *types.Const) error {
-	kind, err := constKind(typ, specName)
+	kind, err := constKind(typ, "spec")
 	if err != nil {
 		return err
 	}
@@ -346,15 +342,15 @@ func (p *Exporter) ExportConst(typ *types.Const) error {
 	c.name = typ.Name()
 	c.kind = kind
 	c.val = fullName
-	if typ.Val().Kind() == constant.Int {
+	if kind == "spec.ConstUnboundInt" && typ.Val().Kind() == constant.Int {
 		value := typ.Val().String()
 		_, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
 			if value[0] == '-' {
-				c.kind = specName + ".Int64"
+				c.kind = "spec.Int64"
 				c.val = "int64(" + fullName + ")"
 			} else {
-				c.kind = specName + ".Uint64"
+				c.kind = "spec.Uint64"
 				c.val = "uint64(" + fullName + ")"
 			}
 		}

--- a/cmd/qexp/gopkg/exporter.go
+++ b/cmd/qexp/gopkg/exporter.go
@@ -387,7 +387,7 @@ func withoutPkg(fullName string) string {
 	if pos < 0 {
 		return fullName
 	}
-	dot := strings.Index(fullName[:pos], ".")
+	dot := strings.LastIndex(fullName[:pos], ".")
 	if dot < 0 {
 		return fullName
 	}

--- a/cmd/qexp/gopkg/exporter.go
+++ b/cmd/qexp/gopkg/exporter.go
@@ -221,7 +221,7 @@ func (p *Exporter) typeString(typ types.Type) string {
 
 func (p *Exporter) fixPkgString(typ string) string {
 	return reTyp.ReplaceAllStringFunc(typ, func(s string) string {
-		pos := strings.Index(s, ".")
+		pos := strings.LastIndex(s, ".")
 		if pos > 0 {
 			pkg := s[:pos]
 			if r, ok := p.imports[pkg]; ok {

--- a/cmd/qexp/gopkg/exporter_test.go
+++ b/cmd/qexp/gopkg/exporter_test.go
@@ -97,8 +97,6 @@ func TestFixPkgString(t *testing.T) {
 	}
 }
 
-// -----------------------------------------------------------------------------
-
 func TestExportStrings(t *testing.T) {
 	err := Export("strings", ioutil.Discard)
 	if err != nil {

--- a/cmd/qexp/gopkg/exporter_test.go
+++ b/cmd/qexp/gopkg/exporter_test.go
@@ -134,7 +134,38 @@ func TestExportGoTypes(t *testing.T) {
 	}
 }
 
-func TestPackage(t *testing.T) {
+func TestExportMath(t *testing.T) {
+	err := Export("math", ioutil.Discard)
+	if err != nil {
+		t.Fatal("TestExport failed:", err)
+	}
+}
+
+func TestImport(t *testing.T) {
+	pkg, err := Import("go/types")
+	if err != nil {
+		t.Fatal("TestImport failed:", err)
+	}
+	if pkg.Path() != "go/types" {
+		t.Fatal(pkg.Path())
+	}
+}
+
+func TestBadImport(t *testing.T) {
+	_, err := Import("go/badtypes")
+	if err == nil {
+		t.Fatal("TestBadImport failed")
+	}
+}
+
+func TestBadExport(t *testing.T) {
+	err := Export("go/badtypes", ioutil.Discard)
+	if err == nil {
+		t.Fatal("TestBadExport failed")
+	}
+}
+
+func TestExportPackage(t *testing.T) {
 	pkg, err := Import("go/build")
 	if err != nil {
 		t.Fatal("TestPackage Import failed:", err)

--- a/cmd/qexp/qexport.go
+++ b/cmd/qexp/qexport.go
@@ -78,6 +78,7 @@ func exportPkg(pkgPath string, libDir string) error {
 	}
 	data, err := format.Source(buf.Bytes())
 	if err != nil {
+		fmt.Println(buf.String())
 		return err
 	}
 	dir := filepath.Join(libDir, pkg.Path())


### PR DESCRIPTION
对 ConstUnboundInt 做检查，所以在 math 库中会出现 int64 和 uint64 转换。
（因为可能使用 gopherjs 32bit 编译，所以保留了 int64 转换）

```
		I.Const("MaxInt32", qspec.ConstUnboundInt, math.MaxInt32),
		I.Const("MaxInt64", qspec.Uint64, uint64(math.MaxInt64)),
		I.Const("MaxInt8", qspec.ConstUnboundInt, math.MaxInt8),
		I.Const("MaxUint16", qspec.ConstUnboundInt, math.MaxUint16),
		I.Const("MaxUint32", qspec.Uint64, uint64(math.MaxUint32)),
		I.Const("MaxUint64", qspec.Uint64, uint64(math.MaxUint64)),
		I.Const("MaxUint8", qspec.ConstUnboundInt, math.MaxUint8),
		I.Const("MinInt16", qspec.ConstUnboundInt, math.MinInt16),
		I.Const("MinInt32", qspec.ConstUnboundInt, math.MinInt32),
		I.Const("MinInt64", qspec.Int64, int64(math.MinInt64)),
		I.Const("MinInt8", qspec.ConstUnboundInt, math.MinInt8),
		I.Const("Phi", qspec.ConstUnboundFloat, math.Phi),
		I.Const("Pi", qspec.ConstUnboundFloat, math.Pi),
```
