### PR TITLE
Use bytes.Buffer to avoid delicate offset operations

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -170,11 +170,11 @@ func parseFileEx(fset *token.FileSet, filename string, code []byte, mode Mode) (
 			if e := errlist[0]; strings.HasPrefix(e.Msg, "expected declaration") {
 				idx := e.Pos.Offset
 				entrypoint := map[bool]string{
-					true:  "func init(){",
-					false: "func main(){",
+					true:  "func init()",
+					false: "func main()",
 				}
 				b.Reset()
-				fmt.Fprintf(&b, "%s%s%s\n}", code[:idx], entrypoint[isMod], code[idx:])
+				fmt.Fprintf(&b, "%s %s{%s}", code[:idx], entrypoint[isMod], code[idx:])
 				code = b.Bytes()
 				hasUnnamed = true
 				err = nil


### PR DESCRIPTION
By using `bytes.Buffer`, we avoid offset magic and error-prone offset values like `n+28`, `b[13:]`, `b[n+12]='\n'`.