### PR TITLE
cmd/qexp/gopkg: adjust import line (goimports style), fix #389

### DIFF
--- a/cmd/qexp/gopkg/exporter_test.go
+++ b/cmd/qexp/gopkg/exporter_test.go
@@ -24,8 +24,9 @@ const expected = `// Package strings provide Go+ "strings" package, as "strings"
 package strings
 
 import (
-	gop "github.com/qiniu/goplus/gop"
 	strings "strings"
+
+	gop "github.com/qiniu/goplus/gop"
 )
 
 func execNewReplacer(arity int, p *gop.Context) {


### PR DESCRIPTION
qexp 代码格式化调整为 goimports 样式，将 标准库和包含了 .-_  的导入行分开。