### PR TITLE
Move function definitions to where they are called

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -222,26 +222,6 @@ func readSource(src interface{}) ([]byte, error) {
 
 // -----------------------------------------------------------------------------
 
-func (p *parser) parseSliceLit(lbrack token.Pos, len ast.Expr) ast.Expr {
-	elts := make([]ast.Expr, 1, 8)
-	elts[0] = len
-	for p.tok == token.COMMA {
-		p.next()
-		elt := p.parseRHS()
-		elts = append(elts, elt)
-	}
-	rbrack := p.expect(token.RBRACK)
-	return &ast.SliceLit{Lbrack: lbrack, Elts: elts, Rbrack: rbrack}
-}
-
-func newSliceLit(lbrack, rbrack token.Pos, len ast.Expr) ast.Expr {
-	var elts []ast.Expr
-	if len != nil {
-		elts = []ast.Expr{len}
-	}
-	return &ast.SliceLit{Lbrack: lbrack, Elts: elts, Rbrack: rbrack}
-}
-
 // astFileToPkg translate ast.File to ast.Package
 func astFileToPkg(file *ast.File, fileName string) (pkg *ast.Package) {
 	pkg = &ast.Package{

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -716,6 +716,26 @@ func (p *parser) parseArrayTypeOrSliceLit(allowSliceLit bool) (expr ast.Expr, is
 	return &ast.ArrayType{Lbrack: lbrack, Len: len, Elt: elt}, false
 }
 
+func (p *parser) parseSliceLit(lbrack token.Pos, len ast.Expr) ast.Expr {
+	elts := make([]ast.Expr, 1, 8)
+	elts[0] = len
+	for p.tok == token.COMMA {
+		p.next()
+		elt := p.parseRHS()
+		elts = append(elts, elt)
+	}
+	rbrack := p.expect(token.RBRACK)
+	return &ast.SliceLit{Lbrack: lbrack, Elts: elts, Rbrack: rbrack}
+}
+
+func newSliceLit(lbrack, rbrack token.Pos, len ast.Expr) ast.Expr {
+	var elts []ast.Expr
+	if len != nil {
+		elts = []ast.Expr{len}
+	}
+	return &ast.SliceLit{Lbrack: lbrack, Elts: elts, Rbrack: rbrack}
+}
+
 func (p *parser) makeIdentList(list []ast.Expr) []*ast.Ident {
 	idents := make([]*ast.Ident, len(list))
 	for i, x := range list {


### PR DESCRIPTION
The following function definitions are in file `parser/parse.go`; however, the only place to call them is `parser/parser.go`.

- `parser.parseSliceLit`
- `newSliceLit`

So, I am moving them from `parser/parse.go` to `parser/parser.go`.