### PR TITLE
qexp: fix typeCast  for types.Basic

### DIFF
--- a/cmd/qexp/gopkg/exporter.go
+++ b/cmd/qexp/gopkg/exporter.go
@@ -202,12 +202,18 @@ func (p *Exporter) sliceCast(varg string, tyElem types.Type) string {
 }
 
 func (p *Exporter) typeCast(varg string, typ types.Type) string {
-	typIntf, isInterface := typ.Underlying().(*types.Interface)
-	if isInterface {
-		if typIntf.Empty() {
+	switch vt := typ.Underlying().(type) {
+	case *types.Interface:
+		if vt.Empty() {
 			return varg
 		}
 		return p.toType(typ) + "(" + varg + ")"
+	case *types.Basic:
+		basic := vt.String()
+		typStr := p.typeString(typ)
+		if basic != typStr {
+			return typStr + "(" + varg + ".(" + basic + "))"
+		}
 	}
 	typStr := p.typeString(typ)
 	return varg + ".(" + typStr + ")"

--- a/lib/flag/gomod_export.go
+++ b/lib/flag/gomod_export.go
@@ -35,13 +35,13 @@ func execBoolVar(_ int, p *gop.Context) {
 
 func execDuration(_ int, p *gop.Context) {
 	args := p.GetArgs(3)
-	ret0 := flag.Duration(args[0].(string), args[1].(time.Duration), args[2].(string))
+	ret0 := flag.Duration(args[0].(string), time.Duration(args[1].(int64)), args[2].(string))
 	p.Ret(3, ret0)
 }
 
 func execDurationVar(_ int, p *gop.Context) {
 	args := p.GetArgs(4)
-	flag.DurationVar(args[0].(*time.Duration), args[1].(string), args[2].(time.Duration), args[3].(string))
+	flag.DurationVar(args[0].(*time.Duration), args[1].(string), time.Duration(args[2].(int64)), args[3].(string))
 	p.PopN(4)
 }
 
@@ -216,13 +216,13 @@ func execmFlagSetFloat64(_ int, p *gop.Context) {
 
 func execmFlagSetDurationVar(_ int, p *gop.Context) {
 	args := p.GetArgs(5)
-	args[0].(*flag.FlagSet).DurationVar(args[1].(*time.Duration), args[2].(string), args[3].(time.Duration), args[4].(string))
+	args[0].(*flag.FlagSet).DurationVar(args[1].(*time.Duration), args[2].(string), time.Duration(args[3].(int64)), args[4].(string))
 	p.PopN(5)
 }
 
 func execmFlagSetDuration(_ int, p *gop.Context) {
 	args := p.GetArgs(4)
-	ret0 := args[0].(*flag.FlagSet).Duration(args[1].(string), args[2].(time.Duration), args[3].(string))
+	ret0 := args[0].(*flag.FlagSet).Duration(args[1].(string), time.Duration(args[2].(int64)), args[3].(string))
 	p.Ret(4, ret0)
 }
 
@@ -253,7 +253,7 @@ func execmFlagSetParsed(_ int, p *gop.Context) {
 
 func execmFlagSetInit(_ int, p *gop.Context) {
 	args := p.GetArgs(3)
-	args[0].(*flag.FlagSet).Init(args[1].(string), args[2].(flag.ErrorHandling))
+	args[0].(*flag.FlagSet).Init(args[1].(string), flag.ErrorHandling(args[2].(int)))
 	p.PopN(3)
 }
 
@@ -311,7 +311,7 @@ func execNFlag(_ int, p *gop.Context) {
 
 func execNewFlagSet(_ int, p *gop.Context) {
 	args := p.GetArgs(2)
-	ret0 := flag.NewFlagSet(args[0].(string), args[1].(flag.ErrorHandling))
+	ret0 := flag.NewFlagSet(args[0].(string), flag.ErrorHandling(args[1].(int)))
 	p.Ret(2, ret0)
 }
 

--- a/lib/os/gomod_export.go
+++ b/lib/os/gomod_export.go
@@ -17,7 +17,7 @@ func execChdir(_ int, p *gop.Context) {
 
 func execChmod(_ int, p *gop.Context) {
 	args := p.GetArgs(2)
-	ret0 := os.Chmod(args[0].(string), args[1].(os.FileMode))
+	ret0 := os.Chmod(args[0].(string), os.FileMode(args[1].(uint32)))
 	p.Ret(2, ret0)
 }
 
@@ -128,7 +128,7 @@ func execmFileWriteString(_ int, p *gop.Context) {
 
 func execmFileChmod(_ int, p *gop.Context) {
 	args := p.GetArgs(2)
-	ret0 := args[0].(*os.File).Chmod(args[1].(os.FileMode))
+	ret0 := args[0].(*os.File).Chmod(os.FileMode(args[1].(uint32)))
 	p.Ret(2, ret0)
 }
 
@@ -359,13 +359,13 @@ func execLstat(_ int, p *gop.Context) {
 
 func execMkdir(_ int, p *gop.Context) {
 	args := p.GetArgs(2)
-	ret0 := os.Mkdir(args[0].(string), args[1].(os.FileMode))
+	ret0 := os.Mkdir(args[0].(string), os.FileMode(args[1].(uint32)))
 	p.Ret(2, ret0)
 }
 
 func execMkdirAll(_ int, p *gop.Context) {
 	args := p.GetArgs(2)
-	ret0 := os.MkdirAll(args[0].(string), args[1].(os.FileMode))
+	ret0 := os.MkdirAll(args[0].(string), os.FileMode(args[1].(uint32)))
 	p.Ret(2, ret0)
 }
 
@@ -389,7 +389,7 @@ func execOpen(_ int, p *gop.Context) {
 
 func execOpenFile(_ int, p *gop.Context) {
 	args := p.GetArgs(3)
-	ret0, ret1 := os.OpenFile(args[0].(string), args[1].(int), args[2].(os.FileMode))
+	ret0, ret1 := os.OpenFile(args[0].(string), args[1].(int), os.FileMode(args[2].(uint32)))
 	p.Ret(3, ret0, ret1)
 }
 


### PR DESCRIPTION
interface{} to types.Basic cast error
```
func execChmod(_ int, p *gop.Context) {
	args := p.GetArgs(2)
	ret0 := os.Chmod(args[0].(string), args[1].(os.FileMode))
	p.Ret(2, ret0)
}
```
fixed to 
```
func execChmod(_ int, p *gop.Context) {
	args := p.GetArgs(2)
	ret0 := os.Chmod(args[0].(string), os.FileMode(args[1].(uint32)))
	p.Ret(2, ret0)
}
```