### PR TITLE
cmd/qexp/gopkg: ignore empty exported pkg, ignore has unexported named param func

### DIFF
--- a/cmd/qexp/gopkg/export.go
+++ b/cmd/qexp/gopkg/export.go
@@ -17,6 +17,7 @@
 package gopkg
 
 import (
+	"errors"
 	"go/importer"
 	"go/types"
 	"io"
@@ -61,6 +62,10 @@ func Import(pkgPath string) (*types.Package, error) {
 	return pkg, nil
 }
 
+var (
+	ErrorIgnore = errors.New("ignore empty exported pkg")
+)
+
 // ExportPackage export types.Package to io.Writer
 func ExportPackage(pkg *types.Package, w io.Writer) (err error) {
 	gbl := pkg.Scope()
@@ -86,6 +91,9 @@ func ExportPackage(pkg *types.Package, w io.Writer) (err error) {
 		if err != nil {
 			return
 		}
+	}
+	if e.IsEmpty() {
+		return ErrorIgnore
 	}
 	return e.Close()
 }

--- a/cmd/qexp/gopkg/exporter_test.go
+++ b/cmd/qexp/gopkg/exporter_test.go
@@ -204,7 +204,7 @@ func TestExportStd(t *testing.T) {
 		}
 		var buf bytes.Buffer
 		err = ExportPackage(p, &buf)
-		if err != nil {
+		if err != nil && err != ErrorIgnore {
 			t.Fatal("export error:", pkg, err)
 		}
 		_, err = format.Source(buf.Bytes())

--- a/cmd/qexp/qexport.go
+++ b/cmd/qexp/qexport.go
@@ -59,9 +59,9 @@ func main() {
 	for _, pkgPath := range flag.Args() {
 		err := exportPkg(pkgPath, libDir)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "export pkg failed:", err)
+			fmt.Fprintf(os.Stderr, "export pkg %q failed, %v\n", pkgPath, err)
 		} else {
-			fmt.Fprintln(os.Stdout, "export pkg success:", pkgPath)
+			fmt.Fprintf(os.Stdout, "export pkg %q success\n", pkgPath)
 		}
 	}
 }


### PR DESCRIPTION
1. 忽略没有导出符号的 pkg, 如 hash 只包含 interface 接口，目前忽略导出。
2. 如果函数参数包含有未导出的 types.Named ，忽略此函数。 如 testing.MainStart(deps testing.testDeps, ...) 