### PR TITLE
WIP Rename parser.init into newParser

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -73,7 +73,8 @@ type parser struct {
 	targetStack [][]*ast.Ident // stack of unresolved labels
 }
 
-func (p *parser) init(fset *token.FileSet, filename string, src []byte, mode Mode) {
+func newParser(fset *token.FileSet, filename string, src []byte, mode Mode) *parser {
+	p := &parser{}
 	p.file = fset.AddFile(filename, -1, len(src))
 	var m scanner.Mode
 	if mode&ParseComments != 0 {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -87,6 +87,7 @@ func newParser(fset *token.FileSet, filename string, src []byte, mode Mode) *par
 	p.trace = mode&Trace != 0 // for convenience (p.trace is used frequently)
 
 	p.next()
+	return p
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
- This renaming is more Go idiomatic.
- Also, this PR restructures the deferred closure in `parseFile`.