### PR TITLE
Deduplicate code in package scanner

### DIFF
--- a/cmd/qfmt/qfmt.go
+++ b/cmd/qfmt/qfmt.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"go/printer"
+	"go/scanner"
 	"io"
 	"io/ioutil"
 	"os"
@@ -16,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/qiniu/goplus/format"
-	"github.com/qiniu/goplus/scanner"
 )
 
 var (

--- a/scanner/errors.go
+++ b/scanner/errors.go
@@ -5,121 +5,13 @@
 package scanner
 
 import (
-	"fmt"
-	"io"
-	"sort"
-
-	"github.com/qiniu/goplus/token"
+	"go/scanner"
 )
 
-// Error - In an ErrorList, an error is represented by an *Error.
-// The position Pos, if valid, points to the beginning of
-// the offending token, and the error condition is described
-// by Msg.
+// Error is an alias of go/scanner.Error
 //
-type Error struct {
-	Pos token.Position
-	Msg string
-}
+type Error = scanner.Error
 
-// Error implements the error interface.
-func (e Error) Error() string {
-	if e.Pos.Filename != "" || e.Pos.IsValid() {
-		// don't print "<unknown position>"
-		// TODO(gri) reconsider the semantics of Position.IsValid
-		return e.Pos.String() + ": " + e.Msg
-	}
-	return e.Msg
-}
-
-// ErrorList is a list of *Errors.
-// The zero value for an ErrorList is an empty ErrorList ready to use.
+// ErrorList is an alias of go/scanner.ErrorList
 //
-type ErrorList []*Error
-
-// Add adds an Error with given position and error message to an ErrorList.
-func (p *ErrorList) Add(pos token.Position, msg string) {
-	*p = append(*p, &Error{pos, msg})
-}
-
-// Reset resets an ErrorList to no errors.
-func (p *ErrorList) Reset() { *p = (*p)[0:0] }
-
-// ErrorList implements the sort Interface.
-func (p ErrorList) Len() int      { return len(p) }
-func (p ErrorList) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
-
-func (p ErrorList) Less(i, j int) bool {
-	e := &p[i].Pos
-	f := &p[j].Pos
-	// Note that it is not sufficient to simply compare file offsets because
-	// the offsets do not reflect modified line information (through //line
-	// comments).
-	if e.Filename != f.Filename {
-		return e.Filename < f.Filename
-	}
-	if e.Line != f.Line {
-		return e.Line < f.Line
-	}
-	if e.Column != f.Column {
-		return e.Column < f.Column
-	}
-	return p[i].Msg < p[j].Msg
-}
-
-// Sort sorts an ErrorList. *Error entries are sorted by position,
-// other errors are sorted by error message, and before any *Error
-// entry.
-//
-func (p ErrorList) Sort() {
-	sort.Sort(p)
-}
-
-// RemoveMultiples sorts an ErrorList and removes all but the first error per line.
-func (p *ErrorList) RemoveMultiples() {
-	sort.Sort(p)
-	var last token.Position // initial last.Line is != any legal error line
-	i := 0
-	for _, e := range *p {
-		if e.Pos.Filename != last.Filename || e.Pos.Line != last.Line {
-			last = e.Pos
-			(*p)[i] = e
-			i++
-		}
-	}
-	(*p) = (*p)[0:i]
-}
-
-// An ErrorList implements the error interface.
-func (p ErrorList) Error() string {
-	switch len(p) {
-	case 0:
-		return "no errors"
-	case 1:
-		return p[0].Error()
-	}
-	return fmt.Sprintf("%s (and %d more errors)", p[0], len(p)-1)
-}
-
-// Err returns an error equivalent to this error list.
-// If the list is empty, Err returns nil.
-func (p ErrorList) Err() error {
-	if len(p) == 0 {
-		return nil
-	}
-	return p
-}
-
-// PrintError is a utility function that prints a list of errors to w,
-// one error per line, if the err parameter is an ErrorList. Otherwise
-// it prints the err string.
-//
-func PrintError(w io.Writer, err error) {
-	if list, ok := err.(ErrorList); ok {
-		for _, e := range list {
-			fmt.Fprintf(w, "%s\n", e)
-		}
-	} else if err != nil {
-		fmt.Fprintf(w, "%s\n", err)
-	}
-}
+type ErrorList = scanner.ErrorList

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -11,6 +11,7 @@ package scanner
 import (
 	"bytes"
 	"fmt"
+	"go/scanner"
 	"path/filepath"
 	"strconv"
 	"unicode"
@@ -24,7 +25,7 @@ import (
 // position and an error message. The position points to the beginning of
 // the offending token.
 //
-type ErrorHandler func(pos token.Position, msg string)
+type ErrorHandler = scanner.ErrorHandler
 
 // A Scanner holds the scanner's internal state while processing
 // a given text. It can be allocated as part of another data


### PR DESCRIPTION
After some experiments in Go Playground, I realized that the `type A = B` syntax in Go is so straightforward that it makes the compiler literally considers A and B are exactly the same thing.

If we attach a method to A, we can call it with a receiver of type B.

If we define a function that accepts a parameter of type A, we can give it a variable of type B.

Then I realized that we can deduplicate pretty much code in package `scanner`.